### PR TITLE
Added legacy accordion template

### DIFF
--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -19,6 +19,11 @@
       "type": "nunjucks"
     },
     {
+      "name": "Accordion (legacy)",
+      "path": "/templates/legacy-accordion.html",
+      "type": "nunjucks"
+    },
+    {
       "name": "Add another",
       "path": "/templates/add-another.html",
       "type": "nunjucks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "home-office-kit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Home Office plugin for GOV.UK prototype kit",
   "author": "Home Office Design System",
   "license": "MIT",

--- a/sass/_accordionLegacy.scss
+++ b/sass/_accordionLegacy.scss
@@ -1,0 +1,233 @@
+// Retrieved on 28 April 2023 from v3.14.0 of GOV.UK frontend https://github.com/alphagov/govuk-frontend/blob/v3.14.0/src/govuk/components/accordion/_index.scss
+
+// Added govuk-accordion--home-office-kit-legacy class modifier, used <div class="govuk-accordion govuk-accordion--home-office-kit-legacy" ... > ... </div>
+.govuk-accordion.govuk-accordion--home-office-kit-legacy {
+  @include govuk-responsive-margin(6, "bottom");
+}
+
+.govuk-accordion--home-office-kit-legacy {
+
+  // Borders between accordion sections
+  .govuk-accordion__section {
+    padding-top: govuk-spacing(3);
+  }
+
+  .govuk-accordion__section-header {
+    padding-top: govuk-spacing(3);
+    padding-bottom: govuk-spacing(3);
+  }
+
+  .govuk-accordion__section-heading {
+    // Override browser defaults to ensure consistent element height
+    // Font size is set in .govuk-accordion__section-button
+    @include govuk-font(24);
+
+    margin-top: 0; // Override browser default
+    margin-bottom: 0; // Override browser default
+  }
+
+  // Buttons within the sections don’t need default styling
+  .govuk-accordion__section-button {
+    @include govuk-font($size: 24, $weight: bold);
+    display: inline-block;
+    margin-bottom: 0;
+    padding-top: govuk-spacing(3);
+  }
+
+  .govuk-accordion__section-summary {
+    margin-top: govuk-spacing(2);
+    margin-bottom: 0;
+  }
+
+  // Remove the bottom margin from the last item inside the content
+  .govuk-accordion__section-content > :last-child {
+    margin-bottom: 0;
+  }
+
+  // Remove the margin from the heading text
+  .govuk-accordion__section-heading-text {
+    margin-bottom: 0px;
+  }
+}
+
+// JavaScript enabled
+.js-enabled {
+
+  .govuk-accordion.govuk-accordion--home-office-kit-legacy {
+    // Border at the bottom of the whole accordion
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+
+  .govuk-accordion--home-office-kit-legacy {
+
+    // Borders between accordion sections
+    .govuk-accordion__section {
+      padding-top: 0;
+    }
+
+    // Hide the body of collapsed sections
+    .govuk-accordion__section-content {
+      display: none;
+      @include govuk-responsive-padding(3, "top");
+      @include govuk-responsive-padding(3, "bottom");
+    }
+
+    // Show the body of expanded sections
+    .govuk-accordion__section--expanded .govuk-accordion__section-content {
+      display: block;
+    }
+
+    // This is styled to look like a link not a button
+    .govuk-accordion__open-all {
+      @include govuk-font($size: 16);
+      position: relative;
+      z-index: 1;
+      margin: 0;
+      padding: 0;
+      border-width: 0;
+      color: $govuk-link-colour;
+      background: none;
+      cursor: pointer;
+      -webkit-appearance: none;
+
+      @include govuk-link-common;
+      @include govuk-link-style-default;
+
+      // Remove default button focus outline in Firefox
+      &::-moz-focus-inner {
+        padding: 0;
+        border: 0;
+      }
+    }
+
+    // Section headers have a pointer cursor as an additional affordance
+    .govuk-accordion__section-header {
+      position: relative;
+      // Safe area on the right to avoid clashing with icon
+      padding-right: 40px;
+      border-top: 1px solid $govuk-border-colour;
+      cursor: pointer;
+    }
+
+    // Buttons within the headers don’t need default styling
+    .govuk-accordion__section-button {
+      @include govuk-typography-common;
+      margin-top: 0;
+      margin-bottom: 0;
+      margin-left: 0;
+      padding: 0;
+      border-width: 0;
+      color: $govuk-link-colour;
+      background: none;
+      text-align: left;
+      cursor: pointer;
+      -webkit-appearance: none;
+
+      &:focus {
+        @include govuk-focused-text;
+      }
+
+      // Remove default button focus outline in Firefox
+      &::-moz-focus-inner {
+        padding: 0;
+        border: 0;
+      }
+    }
+
+    // Extend the touch area of the button to span the section header
+    .govuk-accordion__section-button:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
+
+    .govuk-accordion__section-button:hover:not(:focus) {
+      color: $govuk-link-hover-colour;
+      text-decoration: underline;
+
+      // This needs to come after the text-decoration property otherwise
+      // text-decoration, as a shorthand property, resets it to auto
+      @include govuk-link-hover-decoration;
+      text-underline-offset: $govuk-link-underline-offset;
+    }
+
+    // For devices that can't hover such as touch devices,
+    // remove hover state as it can be stuck in that state (iOS).
+    @media (hover: none) {
+      .govuk-accordion__section-button:hover {
+        text-decoration: none;
+      }
+    }
+
+    .govuk-accordion__controls {
+      text-align: right;
+    }
+
+    // Display an icon to the right of each header to indicate open/closed status,
+    // and as an additional affordance.
+    .govuk-accordion__icon {
+      position: absolute;
+      top: 50%;
+      right: 15px;
+      width: 16px;
+      height: 16px;
+      margin-top: -8px;
+    }
+
+    .govuk-accordion__icon:after,
+    .govuk-accordion__icon:before {
+      content: "";
+      box-sizing: border-box;
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      width: 25%;
+      height: 25%;
+      margin: auto;
+      border: 2px solid transparent;
+      background-color: govuk-colour("black");
+    }
+
+    .govuk-accordion__icon:before {
+      width: 100%;
+    }
+
+    .govuk-accordion__icon:after {
+      height: 100%;
+    }
+
+    // Vertical bar should be hidden when section is open, to display a '-' icon
+    .govuk-accordion__section--expanded .govuk-accordion__icon:after {
+      content: " ";
+      display: none;
+    }
+
+    // Tweaks to change styling
+    // In v4.0.0, 'show-all' was renamed 'open-all'
+    .govuk-accordion__show-all {
+      @extend .govuk-accordion__open-all;
+    }
+
+    // Remove toggle from visual display. Not appropriate for production code.
+    .govuk-accordion__section-toggle {
+      display: none;
+    }
+
+    // Remove the nav chevron from open all
+    .govuk-accordion-nav__chevron {
+      display: none;
+    }
+
+    // Remove focus state from button
+    .govuk-accordion__section-button:focus {
+      background-color: transparent;
+      background: transparent;
+      box-shadow: none;
+    }
+  }
+}

--- a/sass/all.scss
+++ b/sass/all.scss
@@ -11,3 +11,5 @@
 @import "pagination";
 @import "statusMessage";
 @import "timeline";
+
+@import "accordionLegacy";

--- a/templates/legacy-accordion.html
+++ b/templates/legacy-accordion.html
@@ -1,0 +1,73 @@
+{% extends "home-office-kit-layout.html" %}
+
+{% block homeOfficeKit_style %}
+<!-- Add css to apply just to this page. For example:
+.my-style {
+  color: red;
+}
+The <style> tage is already included. -->
+{% endblock %}
+
+{% block content %}
+<!-- Add your page content here -->
+<h1 class="govuk-heading-l">Accordion</h1>
+<p class="govuk-body">This accordion should only be used in prototypes. It is not production code.</p>
+<p class="govuk-body">It looks like the GOV.UK frontend Accordion v3.14, but works with future version of GOV.UK frontend.</p>
+<p class="govuk-body">It allows designers to use the up to date GOV.UK prototype kit, with an older visual style of the accordion (which their service may still be using).</p>
+
+<div class="govuk-accordion govuk-accordion--home-office-kit-legacy" data-module="govuk-accordion" id="accordion-default"  data-i18n.show-all-sections='Open all' data-i18n.hide-all-sections='Close all'>
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+          Writing well for the web
+        </span>
+      </h2>
+      <span class="govuk-accordion__icon"></span>
+    </div>
+    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+      <p class='govuk-body'>This is the content for Writing well for the web.</p>
+    </div>
+  </div>
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+          Writing well for specialists
+        </span>
+      </h2>
+      <span class="govuk-accordion__icon"></span>
+    </div>
+    <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+      <p class='govuk-body'>This is the content for Writing well for specialists.</p>
+    </div>
+  </div>
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+          Know your audience
+        </span>
+      </h2>
+      <span class="govuk-accordion__icon"></span>
+    </div>
+    <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+      <p class='govuk-body'>This is the content for Know your audience.</p>
+    </div>
+  </div>
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+          How people read
+        </span>
+      </h2>
+      <span class="govuk-accordion__icon"></span>
+    </div>
+    <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+      <p class='govuk-body'>This is the content for How people read.</p>
+    </div>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Allows for designers with systems that are using the version of GOV.UK frontend before 4, to accurately prototype using an accordion that looks like the v3 one.

Not to be used in production systems.