### PR TITLE
Remove logs from redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+* removed log lines from Home Office kit radio redirect, which fixed an error caused by structured data
+
 ## 1.0.2
 
 * added more examples to the read me for filters and routes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "home-office-kit",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Home Office plugin for GOV.UK prototype kit",
   "author": "Home Office Design System",
   "license": "MIT",

--- a/routes/all.js
+++ b/routes/all.js
@@ -105,10 +105,8 @@ router.get('*', function(req, res, next) {
   // in the format '<value>~<redirect URL>'
   for (const k in req.session.data) {
     const v = req.session.data[k];
-    console.log(v.includes('~home-office-kit-redirect-to~'))
     if ((typeof v === 'string') && (v.includes('~home-office-kit-redirect-to~'))) {
       const parts = v.split('~home-office-kit-redirect-to~');
-      console.log(parts)
       req.session.data[k] = parts[0];
       const href = parts[1];
       console.log(`Found '~home-office-kit-redirect-to~': redirecting to ${href}`)


### PR DESCRIPTION
This fixes a bug where structured data broke the prototype as the log lines included a 'v.includes' which only works when v is a string.