### PR TITLE
Add plugin metadata.

### DIFF
--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,4 +1,12 @@
 {
+  "meta": {
+    "description": "Plugin for the GOV.UK prototype kit to provide Home Office styles",
+    "urls": {
+      "documentation": "https://github.com/UKHomeOffice/home-office-kit#readme",
+      "releaseNotes": "https://github.com/UKHomeOffice/home-office-kit/releases/tag/v{{version}}",
+      "versionHistory": "https://github.com/UKHomeOffice/home-office-kit/releases"
+    }
+  },
   "assets": [
     "/assets"
   ],

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Home Office Design System",
   "license": "MIT",
   "sass": "sass/all.scss",
+  "scripts": {
+    "test": "npx govuk-prototype-kit@latest validate-plugin"
+  },
   "repository": {
     "type": "git",
     "url": "https://https://github.com/UKHomeOffice/home-office-kit"


### PR DESCRIPTION
We're working on a new plugin page, we'll be making use of new metadata that comes from plugin config.  This PR adds that metadata.

I've also added the validator to the tests, this uses `npx` and `@latest` to always look at the latest requirements.  I recommend this approach but it does erode the purity of repeatable builds, you could hardcode a version number in there or install `govuk-prototype-kit` as a (dev) dependency and remove both `npx` and `@latest`.