### PR TITLE
Ignore all manage prototype and other plugin routes

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -6,12 +6,12 @@ function getHomeOfficeKitConfig() {
   if (prototypeConfig.pluginConfig) {
     homeOfficeKitConfig = prototypeConfig.pluginConfig['home-office-kit'] ? prototypeConfig.pluginConfig['home-office-kit'] : {}
 
-    // If logging the prototype kit data, then by default ignore /plugin-assets/, /public/ and /manage-prorotype/page-found requests
+    // If logging the prototype kit data, then by default ignore /plugin-assets/, /public/, /manage-prorotype/ and /plugin-routes/ requests
     if (homeOfficeKitConfig.logData && !homeOfficeKitConfig.logData.ignoreUrlsStartingWith) {
       if (homeOfficeKitConfig.logData === true) {
         homeOfficeKitConfig.logData = {}
       }
-      homeOfficeKitConfig.logData.ignoreUrlsStartingWith = ["/plugin-assets/", "/public/", "/manage-prototype/page-loaded"]
+      homeOfficeKitConfig.logData.ignoreUrlsStartingWith = ["/plugin-assets/", "/public/", "/manage-prototype/", "/plugin-routes/"]
     }
   } else {
     homeOfficeKitConfig = {}


### PR DESCRIPTION
Additional unhelpful logs were being printed in the terminal.

We should ignore any HTTP requests going to other plugin routes or in manage prototype.

This keeps the focus of the data logging on the behaviour that the user is doing, so that they can see how they are moving from page to page and what the stored data is doing in the prototype.